### PR TITLE
Fix "java.security.InvalidAlgorithmParameterException: parameter obje…

### DIFF
--- a/src/main/java/com/amazonaws/encryptionsdk/internal/TrailingSignatureAlgorithm.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/TrailingSignatureAlgorithm.java
@@ -24,6 +24,9 @@ import com.amazonaws.encryptionsdk.CryptoAlgorithm;
  * NOTE: This is not a stable API and may undergo breaking changes in the future.
  */
 public abstract class TrailingSignatureAlgorithm {
+
+    private static final BouncyCastleProvider BC_PROVIDER = new BouncyCastleProvider();
+
     private TrailingSignatureAlgorithm() {
         /* Do not allow arbitrary subclasses */
     }
@@ -84,7 +87,7 @@ public abstract class TrailingSignatureAlgorithm {
 
         @Override
         public KeyPair generateKey() throws GeneralSecurityException {
-            KeyPairGenerator keyGen = KeyPairGenerator.getInstance("ECDSA", "BC");
+            KeyPairGenerator keyGen = KeyPairGenerator.getInstance("ECDSA", BC_PROVIDER);
             keyGen.initialize(ecSpec, Utils.getSecureRandom());
 
             return keyGen.generateKeyPair();


### PR DESCRIPTION
I have the SAME issue ask reported [https://github.com/aws/aws-encryption-sdk-java/issues/68](https://github.com/aws/aws-encryption-sdk-java/issues/68)

Exception thrown:

```
com.amazonaws.encryptionsdk.exception.AwsCryptoException: java.security.InvalidAlgorithmParameterException: parameter object not a ECParameterSpec
        at com.amazonaws.encryptionsdk.internal.EncryptionHandler.<init>(EncryptionHandler.java:114)
        at com.amazonaws.encryptionsdk.AwsCrypto.encryptData(AwsCrypto.java:185)
        at com.amazonaws.encryptionsdk.AwsCrypto.encryptString(AwsCrypto.java:211)
        at com.amazonaws.encryptionsdk.AwsCrypto.encryptString(AwsCrypto.java:223)

...

Caused by: java.security.InvalidAlgorithmParameterException: parameter object not a ECParameterSpec
        at org.bouncycastle.jcajce.provider.asymmetric.ec.KeyPairGeneratorSpi$EC.initialize(Unknown Source)
        at com.amazonaws.encryptionsdk.internal.EncryptionHandler.generateTrailingSigKeyPair(EncryptionHandler.java:367)
        at com.amazonaws.encryptionsdk.internal.EncryptionHandler.<init>(EncryptionHandler.java:105)
        ... 87 common frames omitted
```

There are two Java apps has with same Bouncy Castle libraries deployed on Tomcat 9.0.13, with JDK 1.8.0_171 on Mac OS X.

```
    $TOMCAT_HOME/webapps/app1/WEB-INF/lib/bcprov-ext-jdk15on-1.55.jar
    $TOMCAT_HOME/webapps/app1/WEB-INF/lib/bcpkix-jdk15on-1.55.jar
    $TOMCAT_HOME/webapps/app1/WEB-INF/lib/bcprov-jdk15on-1.55.jar

    $TOMCAT_HOME/webapps/app2/WEB-INF/lib/bcprov-ext-jdk15on-1.55.jar
    $TOMCAT_HOME/webapps/app2/WEB-INF/lib/bcpkix-jdk15on-1.55.jar
    $TOMCAT_HOME/webapps/app2/WEB-INF/lib/bcprov-jdk15on-1.55.jar
```

bdonlan provided a fix [https://github.com/bdonlan/aws-encryption-sdk-java/commit/d57a75f74e7127eb854fc6fdd231958085d5204d](https://github.com/bdonlan/aws-encryption-sdk-java/commit/d57a75f74e7127eb854fc6fdd231958085d5204d), 

According to him:

> Having multiple versions of Bouncy Castle libraries in class path, and the one that is installed as the JVM-wide JCE "BC" security provider isn't the same one that is being used for the AWS encryption SDK.

or 

> Bouncy Castle libraries loaded via multiple class loaders, even they are on SAME version.

With bdonlan's fix, rebuild aws-encryption-sdk-java from master branch, and rerun the test, all test passed, issue fixed.